### PR TITLE
Move bounds on SSN

### DIFF
--- a/src/Faker/Identification.cs
+++ b/src/Faker/Identification.cs
@@ -46,7 +46,7 @@ namespace Faker
 
         public static string SocialSecurityNumber(bool dashFormat = true)
         {
-            var area = RandomNumber.Next(0, 650);
+            var area = RandomNumber.Next(1, 650);
 
             /*
             Odd numbers, 01 to 09
@@ -60,7 +60,7 @@ namespace Faker
             groups.AddRange(Enumerable.Range(2, 9).Where(z => z % 2 == 0));
             groups.AddRange(Enumerable.Range(11, 99).Where(z => z % 2 == 1));
             var group = groups.ElementAt(RandomNumber.Next(0, groups.Count));
-            var serial = RandomNumber.Next(1, 10000);
+            var serial = RandomNumber.Next(1, 9999);
             var ssn = $"{area:000}-{group:00}-{serial:0000}";
             return !dashFormat ? ssn.Replace("-", "") : ssn;
         }


### PR DESCRIPTION
Up 1 number for area to avoid the possibility of a 000 area, and move the serial numbers down 1 to avoid the case where a 5 digit serial could occur.