### PR TITLE
Fix SSN number range generation and add in Normalized DateOfBirth

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,6 +35,7 @@ var number = Faker.RandomNumber.Next(100); // 30
 var ssn = Faker.Identification.SocialSecurityNumber(); // 249-17-9666
 var mbi = Faker.Identification.MedicareBeneficiaryIdentifier(); // 8NK0Q74KT53
 var nin = Faker.Identification.UKNationalInsuranceNumber(); // YA171053Y
+var dob = Faker.Identification.DateOfBirth(); // 1971-11-16T04:49:22.4759507Z
 ```
 
 Supported versions:

--- a/src/Faker.Net.4.0/Faker.Net.4.0.csproj
+++ b/src/Faker.Net.4.0/Faker.Net.4.0.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Faker.Net.4.0</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Faker.Net.4.5/Faker.Net.4.5.csproj
+++ b/src/Faker.Net.4.5/Faker.Net.4.5.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Faker.Net.4.5</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<LangVersion>8.0</LangVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Faker.Net.4.6/Faker.Net.4.6.csproj
+++ b/src/Faker.Net.4.6/Faker.Net.4.6.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Faker.Net.4.7/Faker.Net.4.7.csproj
+++ b/src/Faker.Net.4.7/Faker.Net.4.7.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Faker.Net.4.8/Faker.Net.4.8.csproj
+++ b/src/Faker.Net.4.8/Faker.Net.4.8.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Faker.Net.Core.3.0/Faker.Net.Core.3.0.csproj
+++ b/src/Faker.Net.Core.3.0/Faker.Net.Core.3.0.csproj
@@ -10,6 +10,7 @@
     <FileVersion>1.0.0.0</FileVersion>
     <PackageProjectUrl>https://github.com/oriches/faker-cs</PackageProjectUrl>
     <IsPackable>false</IsPackable>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Faker.Net.Core.3.1/Faker.Net.Core.3.1.csproj
+++ b/src/Faker.Net.Core.3.1/Faker.Net.Core.3.1.csproj
@@ -9,6 +9,7 @@
     <FileVersion>1.0.0.0</FileVersion>
     <PackageProjectUrl>https://github.com/oriches/faker-cs</PackageProjectUrl>
     <IsPackable>false</IsPackable>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Faker.Net.Standard.2.0/Faker.Net.Standard.2.0.csproj
+++ b/src/Faker.Net.Standard.2.0/Faker.Net.Standard.2.0.csproj
@@ -9,6 +9,7 @@
     <FileVersion>1.0.0.0</FileVersion>
     <PackageProjectUrl>https://github.com/oriches/faker-cs</PackageProjectUrl>
     <IsPackable>false</IsPackable>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Faker.Net.Standard.2.1/Faker.Net.Standard.2.1.csproj
+++ b/src/Faker.Net.Standard.2.1/Faker.Net.Standard.2.1.csproj
@@ -8,6 +8,7 @@
     <FileVersion>1.0.0.0</FileVersion>
     <PackageProjectUrl>https://github.com/oriches/faker-cs</PackageProjectUrl>
     <IsPackable>false</IsPackable>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Faker/Identification.cs
+++ b/src/Faker/Identification.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Faker.Extensions;
 

--- a/src/Faker/Identification.cs
+++ b/src/Faker/Identification.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Faker.Extensions;
 
@@ -44,25 +47,79 @@ namespace Faker
             });
         }
 
+        /// <summary>
+        /// Return a list of integers from min to max value inclusive that satisfy check condition
+        /// </summary>
+        /// <param name="min"></param>
+        /// <param name="max">Inclusive</param>
+        /// <param name="conditionFn">All values are valid if not specified</param>
+        /// <returns></returns>
+        private static IEnumerable<int> Range(int min, int max, Func<int, bool> conditionFn = null)
+        {
+            var range = new List<int>();
+            conditionFn ??= (z => true);
+            if (min > max)
+            {
+                return range;
+            }
+            var current = min;
+            do
+            {
+                if (conditionFn(current))
+                {
+                    range.Add(current);
+                }
+                current++;
+            } while (current <= max);
+            return range;
+        }
+
+        private static readonly Func<int, bool> IsEvenFn = z => z % 2 == 0;
+
         public static string SocialSecurityNumber(bool dashFormat = true)
         {
             var area = RandomNumber.Next(1, 650);
-
             /*
             Odd numbers, 01 to 09
             Even numbers, 10 to 98
             Even numbers, 02 to 08
             Odd numbers, 11 to 99
             */
+            var groups = Range(1, 9, z=> !IsEvenFn(z)).ToList();
+            groups.AddRange(Range(10, 98, IsEvenFn));
+            groups.AddRange(Range(2, 8, IsEvenFn));
+            groups.AddRange(Range(11, 99,z=> !IsEvenFn(z)));
 
-            var groups = Enumerable.Range(1, 10).Where(z => z % 2 == 1).ToList();
-            groups.AddRange(Enumerable.Range(10, 99).Where(z => z % 2 == 0));
-            groups.AddRange(Enumerable.Range(2, 9).Where(z => z % 2 == 0));
-            groups.AddRange(Enumerable.Range(11, 99).Where(z => z % 2 == 1));
             var group = groups.ElementAt(RandomNumber.Next(0, groups.Count));
             var serial = RandomNumber.Next(1, 9999);
             var ssn = $"{area:000}-{group:00}-{serial:0000}";
             return !dashFormat ? ssn.Replace("-", "") : ssn;
+        }
+
+        // https://en.wikipedia.org/wiki/Jeanne_Calment
+        public const int MaxAgeAllowed = 122;
+
+        public static DateTime DateOfBirth()
+        {
+            var rnd = new Random((int) DateTime.UtcNow.Ticks);
+            var first = rnd.NextDouble();
+            var second = rnd.NextDouble();
+            var randStdNormal = Math.Sqrt(-2.0 * Math.Log(first)) * Math.Sin(2.0 * Math.PI * second);
+            const double average = MaxAgeAllowed * .5;
+            var randNormal = average + 46 * randStdNormal;
+            var yearsToSubtract =  (int) Math.Abs(randNormal);
+            if (yearsToSubtract > MaxAgeAllowed)
+            {
+                yearsToSubtract = (int) average;
+            }
+            var now = DateTime.UtcNow;
+            var randomDay = RandomNumber.Next(1, 365); // Skip leap years for simplicity
+            if (yearsToSubtract < 1)
+            {
+                randomDay = RandomNumber.Next(1, now.DayOfYear);
+            }
+            var gaussianDate = now.AddYears(yearsToSubtract * -1).AddDays(randomDay * -1);
+            return gaussianDate;
         }
 
         private static readonly string[] _alphabet = "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z".Split(' ');

--- a/tests/Faker.Tests.Net.4.8/Faker.Tests.Net.4.8.csproj
+++ b/tests/Faker.Tests.Net.4.8/Faker.Tests.Net.4.8.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+	<LangVersion>8.0</LangVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/tests/Faker.Tests.Net.Core.3.1/Faker.Tests.Net.Core.3.1.csproj
+++ b/tests/Faker.Tests.Net.Core.3.1/Faker.Tests.Net.Core.3.1.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Faker.Tests</RootNamespace>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Faker.Tests/IdentificationFixture.cs
+++ b/tests/Faker.Tests/IdentificationFixture.cs
@@ -4,16 +4,30 @@ using NUnit.Framework;
 
 namespace Faker.Tests
 {
-    [TestFixture]
     public class IdentificationFixture
     {
         [Test]
+        public void Should_Create_DateOfBirth()
+        {
+            var dob = Identification.DateOfBirth();
+            Console.WriteLine($@"DateOfBirth=[{dob:O}]");
+            Assert.IsTrue(dob < DateTime.UtcNow);
+            Assert.IsTrue(dob > DateTime.UtcNow.AddYears(Identification.MaxAgeAllowed * -1));
+        }
+
+        [Test]
         public void Should_Create_SSN()
         {
-            var ssn = Identification.SocialSecurityNumber();
-            Console.WriteLine($@"SocialSecurityNumber=[{ssn}]");
-            
-            Assert.IsTrue(Regex.IsMatch(ssn, @"\d{3}-\d{2}-\d{4}"));
+            var ssn = new
+            {
+                WithDashes = Identification.SocialSecurityNumber(),
+                Without = Identification.SocialSecurityNumber(false)
+            };
+
+            Console.WriteLine($@"SocialSecurityNumber=[{ssn.WithDashes}]");
+            Assert.IsTrue(Regex.IsMatch(ssn.WithDashes, @"\d{3}-\d{2}-\d{4}"));
+            Console.WriteLine($@"SocialSecurityNumber=[{ssn.Without}]");
+            Assert.IsTrue(Regex.IsMatch(ssn.Without, @"\d{9}"));
         }
 
         [Test]


### PR DESCRIPTION
- Use `C# 8.0` lang features (for compound assignment)
- Generate a normalized random date of birth with a max of `122` years of age
- Fix the range generators for `SSN` number