### PR TITLE
Align project resource references to standard format

### DIFF
--- a/src/Faker.Net.5.0/Faker.Net.5.0.csproj
+++ b/src/Faker.Net.5.0/Faker.Net.5.0.csproj
@@ -65,7 +65,6 @@
   <ItemGroup>
     <Folder Include="Extensions\" />
     <Folder Include="Helpers\" />
-    <Folder Include="Resources\" />
   </ItemGroup>
 
 </Project>

--- a/src/Faker.Net.Core.3.0/Faker.Net.Core.3.0.csproj
+++ b/src/Faker.Net.Core.3.0/Faker.Net.Core.3.0.csproj
@@ -67,7 +67,6 @@
   <ItemGroup>
     <Folder Include="Extensions\" />
     <Folder Include="Helpers\" />
-    <Folder Include="Resources\" />
   </ItemGroup>
 
 </Project>

--- a/src/Faker.Net.Standard.2.0/Faker.Net.Standard.2.0.csproj
+++ b/src/Faker.Net.Standard.2.0/Faker.Net.Standard.2.0.csproj
@@ -13,10 +13,12 @@
 
   <ItemGroup>
     <Compile Include="..\Faker\Address.cs" Link="Address.cs" />
+    <Compile Include="..\Faker\Boolean.cs" Link="Boolean.cs" />
     <Compile Include="..\Faker\Company.cs" Link="Company.cs" />
     <Compile Include="..\Faker\Config.cs" Link="Config.cs" />
     <Compile Include="..\Faker\Country.cs" Link="Country.cs" />
     <Compile Include="..\Faker\Currency.cs" Link="Currency.cs" />
+    <Compile Include="..\Faker\Enum.cs" Link="Enum.cs" />
     <Compile Include="..\Faker\Extensions\ArrayExtensions.cs" Link="Extensions\ArrayExtensions.cs" />
     <Compile Include="..\Faker\Extensions\EnumerableExtensions.cs" Link="Extensions\EnumerableExtensions.cs" />
     <Compile Include="..\Faker\Extensions\StringExtensions.cs" Link="Extensions\StringExtensions.cs" />
@@ -40,56 +42,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Extensions\" />
-    <Folder Include="Extensions\" />
-    <Folder Include="Helpers\" />
-    <Folder Include="Resources\" />
-    <Folder Include="Resources\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="..\Faker\Resources\Address.de-DE.resx" Link="Resources\Address.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Address.resx" Link="Resources\Address.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Company.de-DE.resx" Link="Resources\Company.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Company.resx" Link="Resources\Company.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
+    <EmbeddedResource Include="..\Faker\Resources\Address.de-DE.resx" Link="Resources\Address.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Address.resx" Link="Resources\Address.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Company.de-DE.resx" Link="Resources\Company.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Company.resx" Link="Resources\Company.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Country.de-DE.resx" Link="Resources\Country.de-DE.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Country.resx" Link="Resources\Country.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Currency.de-DE.resx" Link="Resources\Currency.de-DE.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Currency.resx" Link="Resources\Currency.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Identification.de-DE.resx" Link="Resources\Identification.de-DE.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Identification.resx" Link="Resources\Identification.resx" />
-    <EmbeddedResource Include="..\Faker\Resources\Internet.de-DE.resx" Link="Resources\Internet.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Internet.resx" Link="Resources\Internet.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Lorem.de-DE.resx" Link="Resources\Lorem.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Lorem.resx" Link="Resources\Lorem.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Name.de-DE.resx" Link="Resources\Name.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Name.resx" Link="Resources\Name.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Phone.de-DE.resx" Link="Resources\Phone.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Phone.resx" Link="Resources\Phone.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
+    <EmbeddedResource Include="..\Faker\Resources\Internet.de-DE.resx" Link="Resources\Internet.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Internet.resx" Link="Resources\Internet.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Lorem.de-DE.resx" Link="Resources\Lorem.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Lorem.resx" Link="Resources\Lorem.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Name.de-DE.resx" Link="Resources\Name.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Name.resx" Link="Resources\Name.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Phone.de-DE.resx" Link="Resources\Phone.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Phone.resx" Link="Resources\Phone.resx" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+    <Folder Include="Helpers\" />
+  </ItemGroup>
+  
 </Project>

--- a/src/Faker.Net.Standard.2.1/Faker.Net.Standard.2.1.csproj
+++ b/src/Faker.Net.Standard.2.1/Faker.Net.Standard.2.1.csproj
@@ -13,10 +13,12 @@
 
   <ItemGroup>
     <Compile Include="..\Faker\Address.cs" Link="Address.cs" />
+    <Compile Include="..\Faker\Boolean.cs" Link="Boolean.cs" />
     <Compile Include="..\Faker\Company.cs" Link="Company.cs" />
     <Compile Include="..\Faker\Config.cs" Link="Config.cs" />
     <Compile Include="..\Faker\Country.cs" Link="Country.cs" />
     <Compile Include="..\Faker\Currency.cs" Link="Currency.cs" />
+    <Compile Include="..\Faker\Enum.cs" Link="Enum.cs" />
     <Compile Include="..\Faker\Extensions\ArrayExtensions.cs" Link="Extensions\ArrayExtensions.cs" />
     <Compile Include="..\Faker\Extensions\EnumerableExtensions.cs" Link="Extensions\EnumerableExtensions.cs" />
     <Compile Include="..\Faker\Extensions\StringExtensions.cs" Link="Extensions\StringExtensions.cs" />
@@ -40,56 +42,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Extensions\" />
-    <Folder Include="Extensions\" />
-    <Folder Include="Helpers\" />
-    <Folder Include="Resources\" />
-    <Folder Include="Resources\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="..\Faker\Resources\Address.de-DE.resx" Link="Resources\Address.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Address.resx" Link="Resources\Address.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Company.de-DE.resx" Link="Resources\Company.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Company.resx" Link="Resources\Company.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
+    <EmbeddedResource Include="..\Faker\Resources\Address.de-DE.resx" Link="Resources\Address.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Address.resx" Link="Resources\Address.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Company.de-DE.resx" Link="Resources\Company.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Company.resx" Link="Resources\Company.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Country.de-DE.resx" Link="Resources\Country.de-DE.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Country.resx" Link="Resources\Country.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Currency.de-DE.resx" Link="Resources\Currency.de-DE.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Currency.resx" Link="Resources\Currency.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Identification.de-DE.resx" Link="Resources\Identification.de-DE.resx" />
     <EmbeddedResource Include="..\Faker\Resources\Identification.resx" Link="Resources\Identification.resx" />
-    <EmbeddedResource Include="..\Faker\Resources\Internet.de-DE.resx" Link="Resources\Internet.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Internet.resx" Link="Resources\Internet.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Lorem.de-DE.resx" Link="Resources\Lorem.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Lorem.resx" Link="Resources\Lorem.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Name.de-DE.resx" Link="Resources\Name.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Name.resx" Link="Resources\Name.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Phone.de-DE.resx" Link="Resources\Phone.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Faker\Resources\Phone.resx" Link="Resources\Phone.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
+    <EmbeddedResource Include="..\Faker\Resources\Internet.de-DE.resx" Link="Resources\Internet.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Internet.resx" Link="Resources\Internet.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Lorem.de-DE.resx" Link="Resources\Lorem.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Lorem.resx" Link="Resources\Lorem.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Name.de-DE.resx" Link="Resources\Name.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Name.resx" Link="Resources\Name.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Phone.de-DE.resx" Link="Resources\Phone.de-DE.resx" />
+    <EmbeddedResource Include="..\Faker\Resources\Phone.resx" Link="Resources\Phone.resx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+    <Folder Include="Helpers\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This seems to fix an indirect resource linking issue that pops up in NETStandard 2.0 trying to open a .NET Framework 4.8 resource.

This is to fix the issue #16 brought up about could not find a an embedded resource in NETStandard 2.0