### PR TITLE
Only generate positive integers

### DIFF
--- a/src/Faker/RandomNumber.cs
+++ b/src/Faker/RandomNumber.cs
@@ -11,11 +11,11 @@ namespace Faker
         {
             var bytes = new byte[sizeof(int)]; // 4 bytes
             generator.GetNonZeroBytes(bytes);
-            var val = BitConverter.ToInt32(bytes, 0);
+            var val = BitConverter.ToUInt32(bytes, 0);
             // constrain our values to between our min and max
             // https://stackoverflow.com/a/3057867/86411C:\Work\GitHub\faker-cs\src\Faker\RandomNumber.cs
             var result = ((val - min) % (max - min + 1) + (max - min) + 1) % (max - min + 1) + min;
-            return result;
+            return (int)result;
         }
 
         public static int Next()

--- a/tests/Faker.Tests/RandomNumberFixture.cs
+++ b/tests/Faker.Tests/RandomNumberFixture.cs
@@ -70,5 +70,23 @@ namespace Faker.Tests
 
             Assert.IsTrue(result);
         }
+
+
+        [Test]
+        public void Should_Generate_Values_Greater_Than_Zero()
+        {
+            var result = true;
+            for (var i = 0; i < 1000; i++)
+            {
+                var number = RandomNumber.Next();
+                if (number < 0)
+                {
+                    result = false;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(result);
+        }
     }
 }


### PR DESCRIPTION
When calling RandomNumber.Next() 1/2 the time will return a value less than 0

By always converting to an uint, the calculation below then correctly returns a number between 0 and int.max